### PR TITLE
docs: get non-text contracts into review via cue-omni-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ See [examples/](examples/) for full sample outputs.
 - **US law focus** — analysis defaults to US; provisions vary by jurisdiction
 - **Context window** — very long contracts may need section-by-section review
 
-**The contract has to be text before review can start.** This skill analyzes a contract once it is text. A scan PDF, a clause page someone sent as a link, or a negotiation recording never reaches the analyzer. Run those through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) first to get Markdown — web pages including in-page video/attachments, plus authorized local documents, audio, or video; several local files at once — then review the resulting text, and hand its `redlines.json` to legal-redline-tools against the original `contract.docx`. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
+**The contract has to be text before review can start.** This skill analyzes a contract once it is text. A scan PDF, a clause page someone sent as a link, or a negotiation recording never reaches the analyzer. Run those through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) first to get Markdown — web pages including in-page video/attachments, plus authorized local documents, audio, or video; several local files at once — then review the resulting text. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
 
 ## Accuracy
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ See [examples/](examples/) for full sample outputs.
 - **US law focus** — analysis defaults to US; provisions vary by jurisdiction
 - **Context window** — very long contracts may need section-by-section review
 
+**The contract has to be text before review can start.** This skill analyzes a contract once it is text. A scan PDF, a clause page someone sent as a link, or a negotiation recording never reaches the analyzer. Run those through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) first to get Markdown — web pages including in-page video/attachments, plus authorized local documents, audio, or video; several local files at once — then review the resulting text, and hand its `redlines.json` to legal-redline-tools against the original `contract.docx`. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
+
 ## Accuracy
 
 Based on ContractEval benchmarks, Claude achieves F1 ~0.62 on clause extraction. Best for first-pass review and issue flagging — not a replacement for attorney review on material deals.


### PR DESCRIPTION
> **Disclosure:** I'm a maintainer of [sensedeal/cue-skills](https://github.com/sensedeal/cue-skills) (MIT). This PR adds a note pointing to cue-omni-reader, which I help maintain.

Review runs on a contract once it is text. Real intake is often a scan PDF, a clause page received as a link, or a negotiation recording — none of which reach the analyzer.

After Limitations, this PR adds one note: run the source through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) to Markdown first, then review the text. One-line install, MIT, may bill.

```sh
npx skills add sensedeal/cue-skills --skill cue-omni-reader
```
